### PR TITLE
Added pytorch version to dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -21,7 +21,7 @@ RUN conda create -y -n py36_py041 python=3.6  \
  && /opt/conda/bin/conda install -n py36_py041 -y tqdm -c conda-forge \
  && /opt/conda/bin/conda install -n py36_py041 -y six future \
  && conda create -y -n py36_py121 python=3.6  \
- && /opt/conda/bin/conda install -n py36_py121 -y pytorch torchvision cudatoolkit=9.2 ignite -c pytorch \
+ && /opt/conda/bin/conda install -n py36_py121 -y pytorch=1.2.0 torchvision cudatoolkit=9.2 ignite -c pytorch \
  && /opt/conda/bin/conda install -n py36_py121 -y rdkit=2019.03.4.0 -c rdkit \
  && /opt/conda/bin/conda install -n py36_py121 -y tqdm -c conda-forge \
  && /opt/conda/bin/conda install -n py36_py121 -y pytest arrow ipython future Pillow seaborn \

--- a/scripts/train/train_molecule_chef_qed.py
+++ b/scripts/train/train_molecule_chef_qed.py
@@ -152,7 +152,7 @@ def validation(val_dataloader, ae, tb_writer_val, cuda_details, property_pred_fa
         ['Reconstruct Acc (elem level)', elem_acc_meter.avg],
         ['Prediction MSE', prediction_mse_meter.avg],
     ],
-        tablefmt="simple", floatfmt=".4f").encode('utf-8'))
+        tablefmt="simple", floatfmt=".4f"))
     print("===============================================")
     if tb_writer_val is not None:
         tb_writer_val.add_scalar("total_loss", total_loss_meter.avg)


### PR DESCRIPTION
This PR fixes the versioning for PyTorch in dockerfile as the latest PyTorch (1.5.0) does not work with the current repository.

I have also fixed the `tabulate` print by removing the encoding, which messes up the printing to console.